### PR TITLE
fix: types not defined in package.json `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "exports": {
         ".": {
             "require": "./dist/google-oauth-gsi.cjs",
-            "import": "./dist/google-oauth-gsi.mjs"
+            "import": "./dist/google-oauth-gsi.mjs",
+            "types": "./dist/google-oauth-gsi.d.ts"
         }
     },
     "files": [


### PR DESCRIPTION
This fixes dx issue where types are not working.